### PR TITLE
Re-do the documentation for the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ This is a script designed to take an export of a design system, and insert the t
 
 ## Exporting Data from your Design System
 
-This section is a WIP. It will be devoted to understanding how you can export your design system data, for the script to understand it. Note that at the moment we only support Figma.
+This section is a WIP. 
+
+It will be devoted to understanding how you can export your design system data, for the script to understand it. Note that at the moment we only support Figma. The export should have been done using using [this](https://www.figma.com/community/plugin/843461159747178978) plugin. The format's documentation is a WIP currently.
 
 ## Using the Script
 
-This section is devoted to understanding how you can ingest the exported data using the script, so it's inserted into your `theme.json`.
+Once data has been exported from your design system, into either a folder or a single token JSON file the script is almost ready to be run.
 
-### Assumptions
+There are few more assumptions assumed for the script:
 
-* The export from your design system has been completed. At the moment, this would be from Figma and would include either a single token JSON file or a folder of token JSON files. The export should have been done using using [this](https://www.figma.com/community/plugin/843461159747178978) plugin. The format's documentation is a WIP currently.
 * Knowledge of what exact theme name set you want to pick out from the token JSON export from Figma. An example would be if your main set was `valet` then valet is your theme name set that you want to use.
 * An existing [`theme.json`](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/) file, in where the tokens from your export would be inserted. Note that by default, the script does not overwrite the `theme.json`. Instead, it writes to a new file called `theme.generated.json`. This can be overriden using the `--overwrite` flag.
 * Based on the theme that is selected from the Figma export, the tokens are inserted directly under `settings->custom`. If a section prefix is desired, use the `--themeJsonSection` option.
@@ -47,6 +48,6 @@ THe following is a good summary of available command-line options within the scr
   --overwrite                  overwrite existing theme.json (default: false)
 ```
 
-## Using the New `theme.json`
+## Using the New `theme.json` in the Editor
 
 This section is a WIP. This section will be devoted to understanding how the data that was inserted into the `theme.json` can be used in the editor.


### PR DESCRIPTION
*Description*

This is meant to redo the documentation for how the script is used, as well as add placeholder sections within the main readme. These placeholder sections will be replaced with upcoming documentations in the future. 