### PR TITLE
Update public README links and repository references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WP-THEME-TOKEN-TRANSFORMER
+# vip-design-system-bridge
 
 This is a script designed to take an export of a design system, and insert the tokens into the `theme.json` of a WordPress site. At the moment it only supports exports from Figma, using [this](https://www.figma.com/community/plugin/843461159747178978) plugin.
 

--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@ See **[Figma Tokens Tutorial][docs-figma-tokens-tutorial]**.
 
 ## Using the Script
 
-Once data has been exported from your design system, into either a folder or a single token JSON file the script is almost ready to be run.
+Once data has been exported from your design system, into either a folder or a single JSON token file the script is almost ready to be run.
 
-There are few more assumptions assumed for the script:
+The script makes some assumptions by default, and its critical to ensure that these are correct for your design system:
 
-* For PRO Plugin users: Knowing what exact theme name set you want to pick out from the token JSON export from Figma. An example would be if your main set was `valet` then valet is your theme name set that you want to use.
+* For PRO Plugin users: Know what exact theme name set you want to pick out from the token JSON export from Figma. An example would be if your main set was `valet` then valet is your theme name set that you want to use.
 
 ![Screenshot of a pro plugin user in Figma][png-pro-plugin-usage]
 
-* For NON-PRO Plugin users: Knowing what exactly is the source set, and what is the layer sets that take advantage of the source set from the token JSON export from Figma. It's possible to skip this entirely, and just use all the sets from the export.
+* For NON-PRO Plugin users: Know what exactly is the source set, and the layer sets that take advantage of the source set from the token JSON export from Figma. It's also possible to skip this entirely, and just use all the sets from the export.
 
 ![Screenshot of a non-pro plugin user in Figma][png-non-pro-plugin-usage]
 
-* An existing [`theme.json`](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/) file, in where the tokens from your export would be inserted. Note that by default, the script does not overwrite the `theme.json`. Instead, it writes to a new file called `theme.generated.json`. This can be overriden using the `--overwrite` flag.
+* An existing [`theme.json`](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/) file where the tokens from your export would be inserted. Note that by default, the script does not overwrite the `theme.json`. Instead, it writes to a new file called `theme.generated.json`. This can be overriden using the `--overwrite` flag.
 * Based on the theme that is selected from the Figma export, the tokens are inserted directly under `settings->custom`. If a section prefix is desired, use the `--themeJsonSection` option.
 
 ### Steps
@@ -31,7 +31,7 @@ There are few more assumptions assumed for the script:
 ```bash
 npm install
 ```
-* The script is now ready to run. Please note that by default the script does not overwrite the `theme.json`. Instead, it will write to a file called `theme.generated.json` for safety. Using the `---overwrite` flag will override that and overwrite the `theme.json` instead. The following is how the script would be run:
+* The script is now ready to run. Please note that by default the script does not overwrite the `theme.json`. Instead, it will write to a file called `theme.generated.json` for safety. Using the `---overwrite` flag will overwrite the `theme.json` instead. The following is how the script would be run:
 
 OPTION 1 - FOR PRO PLUGIN USERS
 ```bash
@@ -71,10 +71,6 @@ THe following is a good summary of available command-line options within the scr
   --themeJsonSection <prefix>  section to insert tokens into theme.json->settings->custom (default: "")
   --overwrite                  overwrite existing theme.json (default: false)
 ```
-
-## Using the New `theme.json` in the Editor
-
-This section is a WIP. This section will be devoted to understanding how the data that was inserted into the `theme.json` can be used in the editor.
 
 [png-pro-plugin-usage]: https://github.com/Automattic/vip-design-system-bridge/blob/trunk/docs/assets/pro-plugin-usage.png
 [png-non-pro-plugin-usage]: https://github.com/Automattic/vip-design-system-bridge/blob/trunk/docs/assets/non-pro-plugin-usage.png

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ This is a script designed to take an export of a design system, and insert the t
 
 ## Exporting Data from your Design System
 
-This section is a WIP. 
-
-It will be devoted to understanding how you can export your design system data, for the script to understand it. Note that at the moment we only support Figma. The export should have been done using using [this](https://www.figma.com/community/plugin/843461159747178978) plugin. The format's documentation is a WIP currently.
+See **[Figma Tokens Tutorial](docs-figma-tokens-tutorial)**.
 
 ## Using the Script
 
@@ -80,3 +78,4 @@ This section is a WIP. This section will be devoted to understanding how the dat
 
 [png-pro-plugin-usage]: /docs/assets/pro-plugin-usage.png
 [png-non-pro-plugin-usage]: /docs/assets/non-pro-plugin-usage.png
+[docs-figma-tokens-tutorial]: /docs/design-tokens-example

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a script designed to take an export of a design system, and insert the t
 
 ## Exporting Data from your Design System
 
-See **[Figma Tokens Tutorial](docs-figma-tokens-tutorial)**.
+See **[Figma Tokens Tutorial][docs-figma-tokens-tutorial]**.
 
 ## Using the Script
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,6 @@ THe following is a good summary of available command-line options within the scr
 
 This section is a WIP. This section will be devoted to understanding how the data that was inserted into the `theme.json` can be used in the editor.
 
-[png-pro-plugin-usage]: /docs/assets/pro-plugin-usage.png
-[png-non-pro-plugin-usage]: /docs/assets/non-pro-plugin-usage.png
-[docs-figma-tokens-tutorial]: /docs/design-tokens-example
+[png-pro-plugin-usage]: https://github.com/Automattic/vip-design-system-bridge/blob/trunk/docs/assets/pro-plugin-usage.png
+[png-non-pro-plugin-usage]: https://github.com/Automattic/vip-design-system-bridge/blob/trunk/docs/assets/non-pro-plugin-usage.png
+[docs-figma-tokens-tutorial]: https://github.com/Automattic/vip-design-system-bridge/blob/trunk/docs/design-tokens-example/README.md

--- a/docs/design-tokens-example/README.md
+++ b/docs/design-tokens-example/README.md
@@ -65,7 +65,7 @@ We've created a set of design tokens that are ready to be imported into the desi
 4. Click the "Add new credentials" button. In the "Name" field, enter any name (e.g. `Example Tokens`). In the URL box, enter this URL:
 
     ```
-    https://gist.githubusercontent.com/alecgeatches/d9831e259c06a132e7c7ab9cb52e9454/raw/5cbe4d2796341b6c29acdf7a135f571fc6674cda/tokens.json
+    https://raw.githubusercontent.com/Automattic/vip-design-system-bridge/trunk/docs/design-tokens-example/tokens.json
     ```
 
     The result should look something like this:
@@ -168,8 +168,8 @@ In the following steps we'll update the theme to use the tokens exported from Fi
 ---
 
 [example-figma-document]: https://www.figma.com/file/5NZf8UfaZCPhcZRTjpRfmX/Material-3-Design-Kit---Figma-Tokens-Example
-[example-tokens-raw]: https://gist.githubusercontent.com/alecgeatches/d9831e259c06a132e7c7ab9cb52e9454/raw/5cbe4d2796341b6c29acdf7a135f571fc6674cda/tokens.json
-[example-tokens]: https://gist.github.com/alecgeatches/d9831e259c06a132e7c7ab9cb52e9454
+[example-tokens-raw]: https://raw.githubusercontent.com/Automattic/vip-design-system-bridge/trunk/docs/design-tokens-example/tokens.json
+[example-tokens]: https://github.com/Automattic/vip-design-system-bridge/blob/trunk/docs/design-tokens-example/tokens.json
 [figma-material-3-design-kit]: https://www.figma.com/community/file/1035203688168086460
 [figma-tokens-docs-github]: https://docs.figmatokens.com/sync/github
 [figma-tokens-plugin]: https://www.figma.com/community/plugin/843461159747178978

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "wp-theme-token-transformer",
+	"name": "vip-design-system-bridge",
 	"version": "1.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "wp-theme-token-transformer",
+			"name": "vip-design-system-bridge",
 			"version": "1.0.0",
 			"dependencies": {
 				"chalk": "^4.1.2",
@@ -4897,22 +4897,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/prettier": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-			"integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-			"dev": true,
-			"peer": true,
-			"bin": {
-				"prettier": "bin-prettier.js"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			},
-			"funding": {
-				"url": "https://github.com/prettier/prettier?sponsor=1"
-			}
-		},
 		"node_modules/prettier-linter-helpers": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -5600,20 +5584,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/typescript": {
-			"version": "4.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-			"integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
-			"dev": true,
-			"peer": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
 			}
 		},
 		"node_modules/unbox-primitive": {
@@ -9410,13 +9380,6 @@
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true
 		},
-		"prettier": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-			"integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-			"dev": true,
-			"peer": true
-		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -9933,13 +9896,6 @@
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true
-		},
-		"typescript": {
-			"version": "4.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-			"integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
-			"dev": true,
-			"peer": true
 		},
 		"unbox-primitive": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "wp-theme-token-transformer",
+	"name": "vip-design-system-bridge",
 	"description": "Tool to ingest tokens from a design system into the theme.json of a WP Site",
 	"version": "1.0.0",
 	"dependencies": {
@@ -17,10 +17,10 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/Automattic/wp-theme-token-transformer.git"
+		"url": "git+https://github.com/Automattic/vip-design-system-bridge.git"
 	},
 	"bugs": {
-		"url": "https://github.com/Automattic/wp-theme-token-transformer/issues"
+		"url": "https://github.com/Automattic/vip-design-system-bridge/issues"
 	},
-	"homepage": "https://github.com/Automattic/wp-theme-token-transformer#readme"
+	"homepage": "https://github.com/Automattic/vip-design-system-bridge#readme"
 }


### PR DESCRIPTION
Update token example from gist to in-repo version, and update a few places `wp-theme-token-transformer` was referenced to `vip-design-system-bridge`.